### PR TITLE
Adding type conversion function and unpacks for ctypes

### DIFF
--- a/libraries/comando/comando.cpp
+++ b/libraries/comando/comando.cpp
@@ -43,6 +43,9 @@ void Protocol::send_message(byte *bytes, byte n_bytes) {
 void Protocol::receive_message(byte *bytes, byte n_bytes) {
 };
 
+// =============== TextProtocol ============
+TextProtocol::TextProtocol(Comando & bcmdo): Protocol(bcmdo) {};
+
 // =============== EchoProtocol ============
 EchoProtocol::EchoProtocol(Comando & bcmdo): Protocol(bcmdo) {};
 

--- a/pycomando/protocols/command.py
+++ b/pycomando/protocols/command.py
@@ -17,39 +17,90 @@ types = {
     chr: (
         lambda v: struct.pack('<c', v),
         lambda bs: (1, struct.unpack('<c', bs[0])[0])),
-    ctypes.c_byte: (
-        lambda v: struct.pack('<c', chr(v.value)),
-        lambda bs: (1, struct.unpack('<c', bs[0])[0])),
-    ctypes.c_char: (
-        lambda v: struct.pack('<c', v),
-        lambda bs: (1, struct.unpack('<c', bs[0])[0])),
     int: (
         lambda v: struct.pack('<i', v),
         lambda bs: (2, struct.unpack('<h', bs[:2])[0])),
-    ctypes.c_int16: (
-        lambda v: struct.pack('<h', v.value),
-        lambda bs: (2, struct.unpack('<h', bs[:2])[0])),
-    ctypes.c_uint16: (
-        lambda v: struct.pack('<H', v.value),
-        lambda bs: (2, struct.unpack('<H', bs[:2])[0])),
-    ctypes.c_int32: (
-        lambda v: struct.pack('<i', v.value),
-        lambda bs: (4, struct.unpack('<i', bs[:4])[0])),
-    ctypes.c_uint32: (
-        lambda v: struct.pack('<I', v.value),
-        lambda bs: (4, struct.unpack('<I', bs[:4])[0])),
     float: (
         lambda v: struct.pack('<f', v),
         lambda bs: (4, struct.unpack('<f', bs[:4])[0])),
+    str: (
+        str,  # TODO I think this is wrong, should it pre-pend the length?
+        lambda bs: (bs[0], bs[1:1+ord(bs[0])])),
+    ctypes.c_byte: (
+        lambda v: struct.pack('<b', v.value),
+        lambda bs: (1, ctypes.c_byte(struct.unpack('<b', bs[0])[0]))),
+    ctypes.c_char: (
+        lambda v: struct.pack('<c', v.value),
+        lambda bs: (1, ctypes.c_char(struct.unpack('<c', bs[0])[0]))),
+    ctypes.c_int16: (
+        lambda v: struct.pack('<h', v.value),
+        lambda bs: (2, ctypes.c_int16(struct.unpack('<h', bs[:2])[0]))),
+    ctypes.c_uint16: (
+        lambda v: struct.pack('<H', v.value),
+        lambda bs: (2, ctypes.c_uint16(struct.unpack('<H', bs[:2])[0]))),
+    ctypes.c_int32: (
+        lambda v: struct.pack('<i', v.value),
+        lambda bs: (4, ctypes.c_int32(struct.unpack('<i', bs[:4])[0]))),
+    ctypes.c_uint32: (
+        lambda v: struct.pack('<I', v.value),
+        lambda bs: (4, ctypes.c_uint32(struct.unpack('<I', bs[:4])[0]))),
     ctypes.c_float: (
         lambda v: struct.pack('<f', v.value),
-        lambda bs: (4, struct.unpack('<f', bs[:4])[0])),
-    str: (
-        str,
-        lambda bs: (bs[0], bs[1:1+ord(bs[0])])),
+        lambda bs: (4, ctypes.c_float(struct.unpack('<f', bs[:4])[0]))),
 }
 types[ctypes.c_bool] = types[bool]
 
+
+def test_type_conversion():
+    c = ctypes
+    tests = [
+        (False, '\x00'),
+        (True, '\x01'),  # bool
+        (0, '\x00\x00\x00\x00'),
+        (1, '\x01\x00\x00\x00'),
+        (256, '\x00\x01\x00\x00'),
+        (-1, '\xff\xff\xff\xff'),  # int
+        (0.0, '\x00\x00\x00\x00'),
+        (1.0, '\x00\x00\x80?'),
+        (-1.0, '\x00\x00\x80\xbf'),  # float
+        #('\x00', '\x00'),
+        #('\xff', '\xff'),
+        #('abc', 'abc'),  # TODO fix string packing
+        #(';\x00\n\r,', ';\x00\n\r,'),  # string
+        (c.c_byte(0), '\x00'),
+        (c.c_byte(127), '\x7f'),
+        (c.c_byte(-128), '\x80'),  # c_byte
+        (c.c_char('\x00'), '\x00'),
+        (c.c_char('\xff'), '\xff'),  # c_char
+        (c.c_int16(0), '\x00\x00'),
+        (c.c_int16(1), '\x01\x00'),
+        (c.c_int16(-1), '\xff\xff'),
+        (c.c_int16(256), '\x00\x01'),  # c_int16
+        (c.c_uint16(0), '\x00\x00'),
+        (c.c_uint16(1), '\x01\x00'),
+        (c.c_uint16(256), '\x00\x01'),
+        (c.c_uint16(65535), '\xff\xff'),  # c_uint16
+        (c.c_int32(0), '\x00\x00\x00\x00'),
+        (c.c_int32(1), '\x01\x00\x00\x00'),
+        (c.c_int32(-1), '\xff\xff\xff\xff'),
+        (c.c_int32(256), '\x00\x01\x00\x00'),  # c_int32
+        (c.c_uint32(0), '\x00\x00\x00\x00'),
+        (c.c_uint32(1), '\x01\x00\x00\x00'),
+        (c.c_uint32(256), '\x00\x01\x00\x00'),
+        (c.c_uint32(4294967295), '\xff\xff\xff\xff'),  # c_uint32
+        (c.c_float(0.0), '\x00\x00\x00\x00'),
+        (c.c_float(1.0), '\x00\x00\x80?'),
+        (c.c_float(-1.0), '\x00\x00\x80\xbf'),  # c_float
+    ]
+    for v, r in tests:
+        pv = types[type(v)][0](v)
+        assert pv == r, "[%s pack error] %r != %r" % (type(v), pv, r)
+        uv = types[type(v)][1](r)[1]
+        if hasattr(v, 'value'):
+            e = uv.value == v.value
+        else:
+            e = uv == v
+        assert e, "[%s, unpack error] %r != %r" % (type(v), uv, v)
 
 
 class CommandProtocol(Protocol):

--- a/tests/send_receive/send_messages.py
+++ b/tests/send_receive/send_messages.py
@@ -11,6 +11,8 @@ except ImportError:
     sys.path.append('../../')
     import pycomando
 
+pycomando.protocols.command.test_type_conversion()
+
 port = serial.Serial('/dev/ttyACM0', 9600)
 time.sleep(1)  # wait for arduino
 port.setDTR(level=0)
@@ -57,12 +59,20 @@ def float_arg(cmd):
         print("\t%s: %s" % (i, cmd.get_arg(float)))
 
 
+def string_arg(cmd):
+    print("[cmd]->string_arg: args...")
+    for i in xrange(3):
+        s = cmd.get_arg(str)
+        print("\t%s: %s[%s]" % (i, s, len(s)))
+
+
 text.receive_message = show
 cmd.register_callback(0, no_arg)
 cmd.register_callback(1, bool_arg)
 cmd.register_callback(2, chr_arg)
 cmd.register_callback(3, int_arg)
 cmd.register_callback(4, float_arg)
+cmd.register_callback(5, string_arg)
 
 print("\t<- from computer, -> = from arduino")
 
@@ -78,6 +88,7 @@ cmds = [
     (2, ('\r', '\n', 'a', 'Z', '\x00')),
     (3, (0, 1, -1, 1000000, -1000000)),
     (4, (0.0, 1.0, -1.0, 1.23, -123.0)),
+    (5, ("hi", "hello", "")),
 ]
 
 print
@@ -90,3 +101,6 @@ for (cid, args) in cmds:
     time.sleep(0.5)
     while port.inWaiting():
         com.handle_stream()
+time.sleep(0.5)
+while port.inWaiting():
+    com.handle_stream()

--- a/tests/send_receive/send_messages/send_messages.ino
+++ b/tests/send_receive/send_messages/send_messages.ino
@@ -142,6 +142,31 @@ void float_arg(CommandProtocol *cmd){
   cmd->finish_command();
 };
 
+void string_arg(CommandProtocol *cmd){
+  echo.send_message(com.get_bytes(), com.get_n_bytes());
+  cmd->start_command(5);
+  String s;
+  s = cmd->get_string_arg();
+  if (s == "hi") {
+    cmd->add_string_arg(String("hi"));
+  } else {
+    cmd->add_string_arg(s);
+  };
+  s = cmd->get_string_arg();
+  if (s == "hello") {
+    cmd->add_string_arg(String("hello"));
+  } else {
+    cmd->add_string_arg(s);
+  };
+  s = cmd->get_string_arg();
+  if (s == "") {
+    cmd->add_string_arg(String(""));
+  } else {
+    cmd->add_string_arg(s);
+  };
+  cmd->finish_command();
+};
+
 void setup() {
   // start stream
   Serial.begin(9600);
@@ -154,6 +179,7 @@ void setup() {
   cmd.register_callback(2, chr_arg);
   cmd.register_callback(3, int_arg);
   cmd.register_callback(4, float_arg);
+  cmd.register_callback(5, string_arg);
 }
 
 void loop() {


### PR DESCRIPTION
I think string sending is broken. I think python needs to pad the length at the beginning of the string. I'm not sure if there is arduino code for reading strings and will have to look into this. For now, just don't send string arguments with the command protocol.
